### PR TITLE
smoother animation following roll result

### DIFF
--- a/game/gameEngine.js
+++ b/game/gameEngine.js
@@ -73,6 +73,8 @@ let boardBounds = {}
 let oldP1Position = 1;
 let oldP2Position = 1;
 
+let lastRoll;
+
 //----------------------------------------------------------------------------
 // Engine Functions
 
@@ -284,6 +286,7 @@ async function startPlay()
         diceValue = await rollDieAndGetValue();
 		document.getElementById("rolledValue").innerHTML =  "<b>" + diceValue +  "</b>";
         randomizeDice(diceValue);
+        lastRoll = diceValue;
         let waiting = await haultFlow();
         if(currentPlayerIndex == 0) {
             oldP1Position = currentPlayer.playerPosition;

--- a/game/gameP5.js
+++ b/game/gameP5.js
@@ -40,6 +40,9 @@ function displayPlayerNames() {
     document.getElementById("player2_pos").innerText = players[1].playerPosition;
 }
 
+let p1Path = [];
+let p2Path = [];
+
 function draw() {
   if(playerNamesEntered) {
     background(220);
@@ -51,7 +54,29 @@ function draw() {
     drawSnakes();
     // draw ladders on board
     drawLadders();
-    drawPlayers();
+    //drawPlayers();
+    if (players[0].playerPosition != oldP1Position){
+        let path = (genPathFromRoll(oldP1Position, lastRoll));
+        p1Path = path.reverse();
+        oldP1Position = players[0].playerPosition;
+    }
+    if (p1Path.length > 0){
+        drawPlayer1Moving(p1Path.pop());
+    }
+    else{
+        drawPlayer1Static(getBlockByID(players[0].playerPosition));
+    }
+    if (players[1].playerPosition != oldP2Position){
+        let path = (genPathFromRoll(oldP2Position, lastRoll));
+        p2Path = path.reverse();
+        oldP2Position = players[1].playerPosition;
+    }
+    if (p2Path.length > 0){
+        drawPlayer2Moving(p2Path.pop());
+    }
+    else{
+        drawPlayer2Static(getBlockByID(players[1].playerPosition));
+    }
   }
 }
 //----------------------------------------------------------------------------------------------
@@ -390,11 +415,6 @@ function drawSingleSnake(snake) {
 
 }
 
-
-  
-
-
-
 function star(x, y, radius1, radius2, npoints) {
     let angle = TWO_PI / npoints;
     let halfAngle = angle / 2.0;
@@ -410,26 +430,50 @@ function star(x, y, radius1, radius2, npoints) {
     endShape(CLOSE);
 }
 
-function drawPlayers(){
-    // console.log(players);
-    if(oldP1Position < players[0].playerPosition)
-        oldP1Position += 1;
-    if(oldP1Position > players[0].playerPosition)
-        oldP1Position -= 1;
-    drawPlayer1(getBlockByID(oldP1Position));
-    if(oldP2Position < players[1].playerPosition)
-        oldP2Position += 1;
-    if(oldP2Position > players[1].playerPosition)
-        oldP2Position -= 1;
-    drawPlayer2(getBlockByID(oldP2Position));
+function genPathFromRoll(oldPosition, roll){
+    let path = [];
+    let oldPos = getBlockByID(oldPosition);
+    let i = 1;
+    while(i <= roll){
+        let nextPos = getBlockByID(oldPosition + i);
+        let distX = (nextPos.xpos - oldPos.xpos) / 10;
+        let distY = (nextPos.ypos - oldPos.ypos) / 10;
+        for (let j = 0; j < 10; j ++){
+            if(nextPos.xpos < oldPos.xpos){
+                path.push({x:nextPos.xpos - (10 - j) * distX, y:oldPos.ypos});
+            }
+            else if(nextPos.xpos > oldPos.xpos){
+                path.push({x:oldPos.xpos + j * distX, y:oldPos.ypos});
+            }
+            else if(nextPos.ypos > oldPos.ypos){
+                path.push({x:oldPos.xpos, y:oldPos.ypos + j * distY});
+            }
+            else if(nextPos.ypos > oldPos.ypos){
+                path.push({x:oldPos.xpos, y:nextPos.ypos - (10 - j) * distY});
+            }
+        }
+        oldPos = nextPos;
+        i++;
+    }
+    return path;
 }
 
-function drawPlayer1(pos){
+function drawPlayer1Static(pos){
     fill(255, 0, 0);
     star(pos.xpos, pos.ypos, 20, 10, 5);
 }
 
-function drawPlayer2(pos){
+function drawPlayer2Static(pos){
     fill(0, 0, 255);
     star(pos.xpos, pos.ypos, 10, 20, 5);
+}
+
+function drawPlayer1Moving(path){
+    fill(255, 0, 0);
+    star(path.x, path.y, 20, 10, 5);
+}
+
+function drawPlayer2Moving(path){
+    fill(0, 0, 255);
+    star(path.x, path.y, 10, 20, 5);
 }


### PR DESCRIPTION
Players now have a smooth animation to follow the result of a die roll. They still teleport to follow snakes and ladders. But this is a good basis to do the snake/ladder animation later.